### PR TITLE
Update to changes introduced in language-sally

### DIFF
--- a/lima-sally/src/Language/Sally/Translation.hs
+++ b/lima-sally/src/Language/Sally/Translation.hs
@@ -415,7 +415,7 @@ trQueries name umap chans rules =
           h    = AEla.ruleAssert r
           pre  = SPExpr $ trUExpr id name umap chans ues h
           lts  = mkLetBinds r
-      in Just $ SallyQuery (mkTSystemName name) lts pre
+      in Just $ mkSallyQuery (mkTSystemName name) lts pre
     getAsserts _ = Nothing  -- ord. rules & coverage statements
 
 -- | Translate Atom 'Rule's into 'SallyTransition's. One transition is


### PR DESCRIPTION
Update to changes introduced in [language-sally](https://github.com/GaloisInc/language-sally/commit/8a99d6aa872b6265290b4108cf84c066a454e611). Without this the build fails with:
```sh
src/Language/Sally/Translation.hs:407:12:
    Couldn't match type ‘T.Text -> SallyQuery’ with ‘SallyQuery’
    Expected type: AEla.Rule -> Maybe SallyQuery
      Actual type: AEla.Rule -> Maybe (T.Text -> SallyQuery)
    In the first argument of ‘mapMaybe’, namely ‘getAsserts’
    In the expression: mapMaybe getAsserts rules
```